### PR TITLE
Fix GitHub Actions by moving ENV vars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ jobs:
   tests:
     name: RSpec
     runs-on: ubuntu-latest
+    env:
+      IGDB_CLIENT_ID: ${{ secrets.IGDB_CLIENT_ID }}
+      IGDB_CLIENT_SECRET: ${{ secrets.IGDB_CLIENT_SECRET }}
 
     services:
       postgres:
@@ -39,7 +42,4 @@ jobs:
         run: bundle exec rails db:migrate
 
       - name: Run tests
-        env:
-          IGDB_CLIENT_ID: ${{ secrets.IGDB_CLIENT_ID }}
-          IGDB_CLIENT_SECRET: ${{ secrets.IGDB_CLIENT_SECRET }}
         run: bundle exec rspec


### PR DESCRIPTION
For some reason GitHub Actions have stopped setting ENV vars correctly when they are set at the step level. Moving the ENV vars from the step level up to the job level sets them correctly for some reason.