### PR TITLE
Ignore Optimisation Patches from releases

### DIFF
--- a/lib/igdb/client/games.rb
+++ b/lib/igdb/client/games.rb
@@ -40,7 +40,7 @@ module IGDB
         def import_param_fields
           {
             fields: 'cover.image_id, name, genres, platforms, platforms.platform_family, release_dates.date, ' \
-                    'release_dates.game, release_dates.platform, release_dates.region'
+                    'release_dates.game, release_dates.platform, release_dates.region, release_dates.status'
           }
         end
       end

--- a/lib/igdb/services/import_game.rb
+++ b/lib/igdb/services/import_game.rb
@@ -50,13 +50,22 @@ module IGDB
         end
       end
 
-      def import_releases(game, platforms, releases)
-        releases&.map do |release|
+      def import_releases(game, platforms, release_data)
+        releases = []
+
+        release_data&.each do |release|
           Rails.logger.info("Release found: #{release}")
 
+          if release['status'] == 36
+            Rails.logger.warn('Ignoring Optimization Patch Release')
+            next
+          end
+
           platform = platforms.detect { |plat| plat.igdb_id == release['platform'] }
-          build_release(game, platform, release)
+          releases << build_release(game, platform, release)
         end
+
+        releases
       end
 
       def build_release(game, platform, release_data)


### PR DESCRIPTION
The specs unfortunately still use real requests. The Last of Us Part II in IGDB has added a optimsation patch as a release. We want to ignore these for now as I wouldn't say they are real releases.